### PR TITLE
Support xarray concat, including broadcasting

### DIFF
--- a/virtualizarr/manifests/array.py
+++ b/virtualizarr/manifests/array.py
@@ -144,7 +144,7 @@ class ManifestArray:
 
         return MANIFESTARRAY_HANDLED_ARRAY_FUNCTIONS[func](*args, **kwargs)
 
-    # Everything beyond here is basically to make this array class wrappable by xarray #
+    # Everything beyond here is basically just to make this array class wrappable by xarray #
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> Any:
         """We have to define this in order to convince xarray that this class is a duckarray, even though we will never support ufuncs."""
@@ -192,6 +192,13 @@ class ManifestArray:
                 # TODO expand it into an element-wise result
                 return np.full(shape=self.shape, fill_value=False, dtype=np.dtype(bool))
 
+    def astype(self, dtype: np.dtype, /, *, copy: bool = True) -> "ManifestArray":
+        """Needed because xarray will call this even when it's a no-op"""
+        if dtype != self.dtype:
+            raise NotImplementedError()
+        else:
+            return self
+
     def __getitem__(
         self,
         key,
@@ -200,7 +207,7 @@ class ManifestArray:
         """
         Only supports extremely limited indexing.
 
-        I only added this method because xarray will apparently attempt to index into its lazy indexing classes even if the operation would be a no-op anyway.
+        Only here because xarray will apparently attempt to index into its lazy indexing classes even if the operation would be a no-op anyway.
         """
         from xarray.core.indexing import BasicIndexer
 
@@ -221,7 +228,6 @@ class ManifestArray:
             for axis_indexer in indexer
         ):
             # indexer is all slice(None)'s, so this is a no-op
-            print("__getitem__ called with a no-op")
             return self
         else:
             raise NotImplementedError(f"Doesn't support slicing with {indexer}")

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1,71 +1,8 @@
 import numpy as np
 import xarray as xr
-import xarray.testing as xrt
 
-from virtualizarr.manifests import ChunkEntry, ChunkManifest, ManifestArray
-from virtualizarr.xarray import dataset_from_kerchunk_refs
+from virtualizarr.manifests import ChunkManifest, ManifestArray
 from virtualizarr.zarr import ZArray
-
-
-def test_dataset_from_kerchunk_refs():
-    ds_refs = {
-        "version": 1,
-        "refs": {
-            ".zgroup": '{"zarr_format":2}',
-            "a/.zarray": '{"chunks":[2,3],"compressor":null,"dtype":"<i8","fill_value":null,"filters":null,"order":"C","shape":[2,3],"zarr_format":2}',
-            "a/.zattrs": '{"_ARRAY_DIMENSIONS":["x","y"]}',
-            "a/0.0": ["test1.nc", 6144, 48],
-        },
-    }
-
-    ds = dataset_from_kerchunk_refs(ds_refs)
-
-    assert "a" in ds
-    da = ds["a"]
-    assert isinstance(da.data, ManifestArray)
-    assert da.dims == ("x", "y")
-    assert da.shape == (2, 3)
-    assert da.chunks == (2, 3)
-    assert da.dtype == np.dtype("<i8")
-
-    assert da.data.zarray.compressor is None
-    assert da.data.zarray.filters is None
-    assert da.data.zarray.fill_value is None
-    assert da.data.zarray.order == "C"
-
-    assert da.data.manifest.dict() == {
-        "0.0": {"path": "test1.nc", "offset": 6144, "length": 48}
-    }
-
-
-class TestAccessor:
-    def test_accessor_to_kerchunk_dict(self):
-        arr = ManifestArray(
-            chunkmanifest={"0.0": ChunkEntry(path="test.nc", offset=6144, length=48)},
-            zarray=dict(
-                shape=(2, 3),
-                dtype=np.dtype("<i8"),
-                chunks=(2, 3),
-                compressor=None,
-                filters=None,
-                fill_value=None,
-                order="C",
-            ),
-        )
-        ds = xr.Dataset({"a": (["x", "y"], arr)})
-
-        expected_ds_refs = {
-            "version": 1,
-            "refs": {
-                ".zgroup": '{"zarr_format":2}',
-                "a/.zarray": '{"chunks":[2,3],"compressor":null,"dtype":"<i8","fill_value":null,"filters":null,"order":"C","shape":[2,3],"zarr_format":2}',
-                "a/.zattrs": '{"_ARRAY_DIMENSIONS":["x","y"]}',
-                "a/0.0": ["test.nc", 6144, 48],
-            },
-        }
-
-        result_ds_refs = ds.virtualize.to_kerchunk(format="dict")
-        assert result_ds_refs == expected_ds_refs
 
 
 class TestEquals:
@@ -104,34 +41,3 @@ class TestEquals:
         marr3 = ManifestArray(zarray=zarray, chunkmanifest=manifest3)
         ds3 = xr.Dataset({"a": (["x", "y"], marr3)})
         assert not ds1.equals(ds3)
-
-
-def test_kerchunk_roundtrip_in_memory_no_concat():
-    # Set up example xarray dataset
-    chunks_dict = {
-        "0.0": {"path": "foo.nc", "offset": 100, "length": 100},
-        "0.1": {"path": "foo.nc", "offset": 200, "length": 100},
-    }
-    manifest = ChunkManifest(entries=chunks_dict)
-    marr = ManifestArray(
-        zarray=dict(
-            shape=(2, 4),
-            dtype=np.dtype("<i8"),
-            chunks=(2, 2),
-            compressor=None,
-            filters=None,
-            fill_value=None,
-            order="C",
-        ),
-        chunkmanifest=manifest,
-    )
-    ds = xr.Dataset({"a": (["x", "y"], marr)})
-
-    # Use accessor to write it out to kerchunk reference dict
-    ds_refs = ds.virtualize.to_kerchunk(format="dict")
-
-    # Use dataset_from_kerchunk_refs to reconstruct the dataset
-    roundtrip = dataset_from_kerchunk_refs(ds_refs)
-
-    # Assert equal to original dataset
-    xrt.assert_equal(roundtrip, ds)

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -117,3 +117,50 @@ class TestConcat:
         assert result.data.zarray.fill_value == zarray.fill_value
         assert result.data.zarray.order == zarray.order
         assert result.data.zarray.zarr_format == zarray.zarr_format
+
+    def test_concat_along_new_dim(self):
+        # this calls np.stack internally
+        # both manifest arrays in this example have the same zarray properties
+        zarray = ZArray(
+            chunks=(5, 10),
+            compressor="zlib",
+            dtype=np.dtype("int32"),
+            fill_value=0.0,
+            filters=None,
+            order="C",
+            shape=(5, 20),
+            zarr_format=2,
+        )
+
+        chunks_dict1 = {
+            "0.0": {"path": "foo.nc", "offset": 100, "length": 100},
+            "0.1": {"path": "foo.nc", "offset": 200, "length": 100},
+        }
+        manifest1 = ChunkManifest(entries=chunks_dict1)
+        marr1 = ManifestArray(zarray=zarray, chunkmanifest=manifest1)
+        ds1 = xr.Dataset({"a": (["x", "y"], marr1)})
+
+        chunks_dict2 = {
+            "0.0": {"path": "foo.nc", "offset": 300, "length": 100},
+            "0.1": {"path": "foo.nc", "offset": 400, "length": 100},
+        }
+        manifest2 = ChunkManifest(entries=chunks_dict2)
+        marr2 = ManifestArray(zarray=zarray, chunkmanifest=manifest2)
+        ds2 = xr.Dataset({"a": (["x", "y"], marr2)})
+
+        result = xr.concat([ds1, ds2], dim="z")["a"]
+
+        # xarray.concat adds new dimensions along axis=0
+        assert result.shape == (2, 5, 20)
+        assert result.chunks == (1, 5, 10)
+        assert result.data.manifest.dict() == {
+            "0.0.0": {"path": "foo.nc", "offset": 100, "length": 100},
+            "0.0.1": {"path": "foo.nc", "offset": 200, "length": 100},
+            "1.0.0": {"path": "foo.nc", "offset": 300, "length": 100},
+            "1.0.1": {"path": "foo.nc", "offset": 400, "length": 100},
+        }
+        assert result.data.zarray.compressor == zarray.compressor
+        assert result.data.zarray.filters == zarray.filters
+        assert result.data.zarray.fill_value == zarray.fill_value
+        assert result.data.zarray.order == zarray.order
+        assert result.data.zarray.zarr_format == zarray.zarr_format

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -70,3 +70,50 @@ class TestEquals:
         marr3 = ManifestArray(zarray=zarray, chunkmanifest=manifest3)
         ds3 = xr.Dataset({"a": (["x", "y"], marr3)})
         assert not ds1.equals(ds3)
+
+
+class TestConcat:
+    def test_concat_along_existing_dim(self):
+        # both manifest arrays in this example have the same zarray properties
+        zarray = ZArray(
+            chunks=(1, 10),
+            compressor="zlib",
+            dtype=np.dtype("int32"),
+            fill_value=0.0,
+            filters=None,
+            order="C",
+            shape=(1, 20),
+            zarr_format=2,
+        )
+
+        chunks_dict1 = {
+            "0.0": {"path": "foo.nc", "offset": 100, "length": 100},
+            "0.1": {"path": "foo.nc", "offset": 200, "length": 100},
+        }
+        manifest1 = ChunkManifest(entries=chunks_dict1)
+        marr1 = ManifestArray(zarray=zarray, chunkmanifest=manifest1)
+        ds1 = xr.Dataset({"a": (["x", "y"], marr1)})
+
+        chunks_dict2 = {
+            "0.0": {"path": "foo.nc", "offset": 300, "length": 100},
+            "0.1": {"path": "foo.nc", "offset": 400, "length": 100},
+        }
+        manifest2 = ChunkManifest(entries=chunks_dict2)
+        marr2 = ManifestArray(zarray=zarray, chunkmanifest=manifest2)
+        ds2 = xr.Dataset({"a": (["x", "y"], marr2)})
+
+        result = xr.concat([ds1, ds2], dim="x")["a"]
+
+        assert result.shape == (2, 20)
+        assert result.chunks == (1, 10)
+        assert result.data.manifest.dict() == {
+            "0.0": {"path": "foo.nc", "offset": 100, "length": 100},
+            "0.1": {"path": "foo.nc", "offset": 200, "length": 100},
+            "1.0": {"path": "foo.nc", "offset": 300, "length": 100},
+            "1.1": {"path": "foo.nc", "offset": 400, "length": 100},
+        }
+        assert result.data.zarray.compressor == zarray.compressor
+        assert result.data.zarray.filters == zarray.filters
+        assert result.data.zarray.fill_value == zarray.fill_value
+        assert result.data.zarray.order == zarray.order
+        assert result.data.zarray.zarr_format == zarray.zarr_format


### PR DESCRIPTION
Closes part of #2.

To get this to work I had to add broadcasting, to cover times when xarray wants to insert a length-1 dimension. I did appreciate until now that actually we can go further and fully support broadcasting with `ManifestArray` objects!