### PR TITLE
Refactor test case virtual dataset creation into pytest fixture. 

### DIFF
--- a/virtualizarr/tests/conftest.py
+++ b/virtualizarr/tests/conftest.py
@@ -29,3 +29,17 @@ def netcdf4_files(tmpdir):
     ds2.to_netcdf(filepath2)
 
     return filepath1, filepath2
+
+@pytest.fixture
+def concated_virtual_dataset_with_indexes(netcdf4_files):
+        """Fixture to supply concatenated virtual dataset including indexes"""
+        from virtualizarr import open_virtual_dataset
+
+        filepath1, filepath2 = netcdf4_files
+
+        vds1 = open_virtual_dataset(filepath1)
+        vds2 = open_virtual_dataset(filepath2)
+
+        return xr.combine_by_coords(
+            [vds2, vds1],
+        )

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -257,14 +257,8 @@ def index_mappings_equal(indexes1: Mapping[str, Index], indexes2: Mapping[str, I
 
 
 class TestCombineUsingIndexes:
-    def test_combine_by_coords(self, netcdf4_files):
-        filepath1, filepath2 = netcdf4_files
+    def test_combine_by_coords(self, concated_virtual_dataset_with_indexes):
 
-        vds1 = open_virtual_dataset(filepath1)
-        vds2 = open_virtual_dataset(filepath2)
-
-        combined_vds = xr.combine_by_coords(
-            [vds2, vds1],
-        )
+        combined_vds = concated_virtual_dataset_with_indexes
 
         assert combined_vds.xindexes["time"].to_pandas_index().is_monotonic_increasing


### PR DESCRIPTION
Moved logic from test_combine_by_coords for creating a virtual dataset into a fixture for re-use.