### PR TITLE
Load selected variables instead of making them virtual

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -277,6 +277,36 @@ TODO: Reinstate this part of the docs once [GH issue #18](https://github.com/Tom
 
 TODO: Use preprocess to create a new index from the metadata
 
+## Loading variables
+
+Whilst the values of virtual variables (i.e. those backed by `ManifestArray` objects) cannot be loaded into memory, you do have the option of opening specific variables from the file as loadable lazy numpy/dask arrays, just like `xr.open_dataset` normally returns. These variables are specified using the `loadable_variables` argument:
+
+```python
+vds = open_virtual_dataset('air.nc', loadable_variables=['air', 'time'])
+```
+```python
+<xarray.Dataset> Size: 31MB
+Dimensions:  (time: 2920, lat: 25, lon: 53)
+Coordinates:
+    lat      (lat) float32 100B ManifestArray<shape=(25,), dtype=float32, chu...
+    lon      (lon) float32 212B ManifestArray<shape=(53,), dtype=float32, chu...
+  * time     (time) datetime64[ns] 23kB 2013-01-01 ... 2014-12-31T18:00:00
+Data variables:
+    air      (time, lat, lon) float64 31MB ...
+Attributes:
+    Conventions:  COARDS
+    description:  Data is from NMC initialized reanalysis\n(4x/day).  These a...
+    platform:     Model
+    references:   http://www.esrl.noaa.gov/psd/data/gridded/data.ncep.reanaly...
+    title:        4x daily NMC reanalysis (1948)
+```
+You can see that the dataset contains a mixture of virtual variables backed by `ManifestArray` objects, and loadable variables backed by (lazy) numpy arrays.
+
+Loading variables can be useful in a few scenarios:
+1. You need to look at the actual values of a muilti-dimensional variable in order to decide what to do next,
+2. Storing a variable on-disk as a set of references would be inefficient, e.g. because it's a very small array (saving the values like this is similar to kerchunk's concept of "inlining" data),
+3. The variable has encoding, and the simplest way to decode it correctly is to let xarray's standard decoding machinery load it into memory and apply the decoding.
+
 ## Writing virtual stores to disk
 
 Once we've combined references to all the chunks of all our legacy files into one virtual xarray dataset, we still need to write these references out to disk so that they can be read by our analysis code later.
@@ -300,6 +330,10 @@ fs = fsspec.filesystem("reference", fo=f"combined.json")
 mapper = fs.get_mapper("")
 
 combined_ds = xr.open_dataset(mapper, engine="kerchunk")
+```
+
+```{note}
+Currently you can only serialize virtual variables backed by `ManifestArray` objects to kerchunk reference files, not real in-memory numpy-backed variables.
 ```
 
 ### Writing as Zarr

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -282,11 +282,7 @@ class TestLoadVirtualDataset:
             else:
                 assert isinstance(vds[name].data, ManifestArray), name
 
-        print(vds)
-
         full_ds = xr.open_dataset(netcdf4_file)
         for name in full_ds.variables:
             if name in vars_to_load:
-                print(vds.variables[name])
-                print(full_ds.variables[name])
                 xrt.assert_identical(vds.variables[name], full_ds.variables[name])

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -2,6 +2,7 @@ from typing import Mapping
 
 import numpy as np
 import xarray as xr
+import xarray.testing as xrt
 from xarray.core.indexes import Index
 
 from virtualizarr import open_virtual_dataset
@@ -268,3 +269,24 @@ class TestCombineUsingIndexes:
         )
 
         assert combined_vds.xindexes["time"].to_pandas_index().is_monotonic_increasing
+
+
+class TestLoadVirtualDataset:
+    def test_load_variables(self, netcdf4_file):
+        vars_to_load = ['air', 'time']
+        vds = open_virtual_dataset(netcdf4_file, load_variables=vars_to_load)
+
+        for name in vds.variables:
+            if name in vars_to_load:
+                assert isinstance(vds[name].data, np.ndarray), name
+            else:
+                assert isinstance(vds[name].data, ManifestArray), name
+
+        print(vds)
+
+        full_ds = xr.open_dataset(netcdf4_file)
+        for name in full_ds.variables:
+            if name in vars_to_load:
+                print(vds.variables[name])
+                print(full_ds.variables[name])
+                xrt.assert_identical(vds.variables[name], full_ds.variables[name])

--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -272,9 +272,9 @@ class TestCombineUsingIndexes:
 
 
 class TestLoadVirtualDataset:
-    def test_load_variables(self, netcdf4_file):
+    def test_loadable_variables(self, netcdf4_file):
         vars_to_load = ['air', 'time']
-        vds = open_virtual_dataset(netcdf4_file, load_variables=vars_to_load)
+        vds = open_virtual_dataset(netcdf4_file, loadable_variables=vars_to_load)
 
         for name in vds.variables:
             if name in vars_to_load:


### PR DESCRIPTION
Towards implementing case (1) of #62, at least the opening step. We would still need to be able to save these loaded variables out (to kerchunk and zarr ideally). 

~~Mostly works but there is a subtlety with the difference between a `Variable` and an `IndexVariable` causing the test to fail.~~