### PR TITLE
Remove python 3.12 from CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We had to pin kerchunk=0.2.2 because of this bug (https://github.com/fsspec/kerchunk/issues/445), but apparently that version of kerchunk cannot work in an environment with python 3.12 (see [this CI run](https://github.com/TomNicholas/VirtualiZarr/actions/runs/8578684155/job/23512827135) for example).