### PR TITLE
Fix bug with expand dims of a scalar array

### DIFF
--- a/virtualizarr/manifests/manifest.py
+++ b/virtualizarr/manifests/manifest.py
@@ -99,13 +99,13 @@ class ChunkManifest(BaseModel):
         return f"ChunkManifest<shape={self.shape_chunk_grid}>"
 
     def __getitem__(self, key: ChunkKey) -> ChunkEntry:
-        return self.chunks[key]
+        return self.entries[key]
 
     def __iter__(self) -> Iterator[ChunkKey]:
-        return iter(self.chunks.keys())
+        return iter(self.entries.keys())
 
     def __len__(self) -> int:
-        return len(self.chunks)
+        return len(self.entries)
 
     def dict(self) -> dict[str, dict[str, Union[str, int]]]:
         """Converts the entire manifest to a nested dictionary."""

--- a/virtualizarr/tests/__init__.py
+++ b/virtualizarr/tests/__init__.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from virtualizarr.manifests import ChunkEntry, ChunkManifest, ManifestArray
+from virtualizarr.zarr import ZArray
+
+
+def create_manifestarray(
+    shape: tuple[int, ...], chunks: tuple[int, ...]
+) -> ManifestArray:
+    """
+    Create an example ManifestArray with sensible defaults.
+    """
+
+    zarray = ZArray(
+        chunks=chunks,
+        compressor="zlib",
+        dtype=np.dtype("float32"),
+        fill_value=0.0,  # TODO change this to NaN?
+        filters=None,
+        order="C",
+        shape=shape,
+        zarr_format=2,
+    )
+
+    if shape != ():
+        raise NotImplementedError(
+            "Only generation of array representing a single scalar currently supported"
+        )
+
+    # TODO generalize this
+    chunkmanifest = ChunkManifest(
+        entries={"0": ChunkEntry(path="scalar.nc", offset=6144, length=48)}
+    )
+
+    return ManifestArray(chunkmanifest=chunkmanifest, zarray=zarray)

--- a/virtualizarr/tests/test_manifests/test_array.py
+++ b/virtualizarr/tests/test_manifests/test_array.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from virtualizarr.manifests import ChunkManifest, ManifestArray
+from virtualizarr.tests import create_manifestarray
 from virtualizarr.zarr import ZArray
 
 
@@ -120,6 +121,16 @@ class TestEquals:
 
     @pytest.mark.skip(reason="Not Implemented")
     def test_partly_equals(self): ...
+
+
+class TestBroadcast:
+    def test_broadcast_scalar(self):
+        # regression test
+        marr = create_manifestarray(shape=(), chunks=())
+        expanded = np.broadcast_to(marr, shape=(1,))
+        assert expanded.shape == (1,)
+        assert expanded.chunks == (1,)
+        assert expanded.manifest == marr.manifest
 
 
 # TODO we really need some kind of fixtures to generate useful example data


### PR DESCRIPTION
Fixes the other part of #100, specifically that when broadcasting a scalar array (i.e. a `ManifestArray` with `shape=()`), you need to not insert a new dimension into the chunk keys, because the chunk key is already `0` (not an empty string).