### PR TITLE
Unpin kerchunk (set floor) and enable Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "xarray@git+https://github.com/pydata/xarray.git@main#egg=xarray",
-    "kerchunk@git+https://github.com/fsspec/kerchunk.git@main#egg=kerchunk",
+    "kerchunk>=0.2.5",
     "h5netcdf",
     "pydantic",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,13 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "xarray@git+https://github.com/pydata/xarray.git@main#egg=xarray",
-    "kerchunk==0.2.2",
+    "kerchunk@git+https://github.com/fsspec/kerchunk.git@main#egg=kerchunk",
     "h5netcdf",
     "pydantic",
     "numpy",


### PR DESCRIPTION
Closes https://github.com/TomNicholas/VirtualiZarr/issues/77

Given that https://github.com/fsspec/kerchunk/issues/445 seems to be resolved on main. This PR unpins the kerchunk version and uses ~the unreleased version~ newly released 0.2.5 instead. ~To me it seems fair that this library would sometimes require unreleased kerchunk and that feels preferable to pinning down to an old release.~