### PR TITLE
Depend on latest version of xarray

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,8 +8,6 @@ cd VirtualiZarr
 pip install -e .
 ```
 
-You will also need a specific branch of xarray in order for concatenation without indexes to work. (See [this comment](https://github.com/TomNicholas/VirtualiZarr/issues/14#issuecomment-2018369470).)
-
 
 ## Install Test Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
-    "xarray@git+https://github.com/pydata/xarray.git@main#egg=xarray",
+    "xarray>=2024.5.0",
     "kerchunk>=0.2.5",
     "h5netcdf",
     "pydantic",


### PR DESCRIPTION
Xarray [v2024.5.0](https://github.com/pydata/xarray/releases/tag/v2024.05.0) has the PR we need for concatenation without indexes (https://github.com/pydata/xarray/pull/8872) so we can depend on a proper released version of xarray from now on.