### PR TITLE
Write to parquet

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -311,26 +311,35 @@ Once we've combined references to all the chunks of all our legacy files into on
 
 The [kerchunk library](https://github.com/fsspec/kerchunk) has its own [specification](https://fsspec.github.io/kerchunk/spec.html) for how byte range references should be serialized (either as a JSON or parquet file).
 
-To write out all the references in the virtual dataset as a single kerchunk-compliant JSON file, you can use the {py:meth}`ds.virtualize.to_kerchunk <virtualizarr.xarray.VirtualiZarrDatasetAccessor.to_kerchunk>` accessor method.
+To write out all the references in the virtual dataset as a single kerchunk-compliant JSON or parquet file, you can use the {py:meth}`ds.virtualize.to_kerchunk <virtualizarr.xarray.VirtualiZarrDatasetAccessor.to_kerchunk>` accessor method.
 
 ```python
 combined_vds.virtualize.to_kerchunk('combined.json', format='json')
 ```
 
-These references can now be interpreted like they were a Zarr store by [fsspec](https://github.com/fsspec/filesystem_spec), using kerchunk's built-in xarray backend (so you need kerchunk to be installed to use `engine='kerchunk'`).
+These references can now be interpreted like they were a Zarr store by [fsspec](https://github.com/fsspec/filesystem_spec), using kerchunk's built-in xarray backend (kerchunk must be installed to use `engine='kerchunk'`).
 
 ```python
-import fsspec
-
-fs = fsspec.filesystem("reference", fo=f"combined.json")
-mapper = fs.get_mapper("")
-
-combined_ds = xr.open_dataset(mapper, engine="kerchunk")
+combined_ds = xr.open_dataset('combined.json', engine="kerchunk")
 ```
 
 ```{note}
 Currently you can only serialize virtual variables backed by `ManifestArray` objects to kerchunk reference files, not real in-memory numpy-backed variables.
 ```
+
+When you have many chunks, the reference file can get large enough to be unwieldy as json. In that case the references can be instead stored as parquet. Again this uses kerchunk internally.
+
+```python
+combined_vds.virtualize.to_kerchunk('combined.parq', format='parquet')
+```
+
+And again we can read these references using the "kerchunk" backend as if it were a regular Zarr store
+
+```python
+combined_ds = xr.open_dataset('combined.parq', engine="kerchunk")
+```
+
+By default references are placed in separate parquet file when the total number of references exceeds `record_size`. If there are fewer than `categorical_threshold` unique urls referenced by a particular variable, url will be stored as a categorical variable.
 
 ### Writing as Zarr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ test = [
     "scipy",
     "pooch",
     "ruff",
-
+    "fastparquet",
 ]
 
 

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -1,4 +1,6 @@
+import pytest
 import xarray as xr
+import xarray.testing as xrt
 
 from virtualizarr import open_virtual_dataset
 
@@ -11,3 +13,24 @@ def test_open_scalar_variable(tmpdir):
 
     vds = open_virtual_dataset(f"{tmpdir}/scalar.nc")
     assert vds["a"].shape == ()
+
+
+@pytest.mark.parametrize("format", ["json", "parquet"])
+def test_kerchunk_roundtrip(tmpdir, format):
+    # set up example xarray dataset
+    ds = xr.tutorial.open_dataset("air_temperature", decode_times=False)
+
+    # save it to disk as netCDF (in temporary directory)
+    ds.to_netcdf(f"{tmpdir}/air.nc")
+
+    # use open_virtual_dataset to read it as references
+    vds = open_virtual_dataset(f"{tmpdir}/air.nc")
+
+    # write those references to disk as kerchunk json
+    vds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)
+
+    # read the dataset from disk via the zarr store
+    roundtrip = xr.open_dataset(f"{tmpdir}/refs.{format}", engine="kerchunk")
+
+    # assert equal to original dataset
+    xrt.assert_equal(roundtrip, ds)

--- a/virtualizarr/tests/test_integration.py
+++ b/virtualizarr/tests/test_integration.py
@@ -24,7 +24,7 @@ def test_kerchunk_roundtrip(tmpdir, format):
     ds.to_netcdf(f"{tmpdir}/air.nc")
 
     # use open_virtual_dataset to read it as references
-    vds = open_virtual_dataset(f"{tmpdir}/air.nc")
+    vds = open_virtual_dataset(f"{tmpdir}/air.nc", indexes={})
 
     # write those references to disk as kerchunk json
     vds.virtualize.to_kerchunk(f"{tmpdir}/refs.{format}", format=format)

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -359,12 +359,14 @@ class VirtualiZarrDatasetAccessor:
     ) -> KerchunkStoreRefs: ...
 
     @overload
-    def to_kerchunk(self, filepath: str | Path, format: Literal["json"]) -> None: ...
+    def to_kerchunk(
+        self, filepath: Union[str, Path], format: Literal["json"]
+    ) -> None: ...
 
     @overload
     def to_kerchunk(
         self,
-        filepath: str | Path,
+        filepath: Union[str, Path],
         format: Literal["parquet"],
         record_size: int = 100_000,
         categorical_threshold: int = 10,
@@ -372,7 +374,7 @@ class VirtualiZarrDatasetAccessor:
 
     def to_kerchunk(
         self,
-        filepath: str | Path | None = None,
+        filepath: Optional[Union[str, Path]] = None,
         format: Union[Literal["dict"], Literal["json"], Literal["parquet"]] = "dict",
         record_size: int = 100_000,
         categorical_threshold: int = 10,
@@ -419,11 +421,14 @@ class VirtualiZarrDatasetAccessor:
             elif isinstance(filepath, str):
                 url = filepath
 
-            return refs_to_dataframe(
+            # refs_to_dataframe is responsible for writing to parquet.
+            # at no point does it create a full in-memory dataframe.
+            refs_to_dataframe(
                 refs,
                 url=url,
                 record_size=record_size,
                 categorical_threshold=categorical_threshold,
             )
+            return None
         else:
             raise ValueError(f"Unrecognized output format: {format}")


### PR DESCRIPTION
Closes #72 

I'm pretty sure this is not what you had in mind, but wanted to put this up as at least an option. Even if we scrap the implementation, the test should stay the same.

I didn't include remote writing since it seemed like that would be something that we'd want to implement for all the file outputs not just for one. 