### PR TITLE
requires-python = ">=3.10"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "xarray>=2024.5.0",


### PR DESCRIPTION
Fix for an error that arises when using python3.9:

```
Python 3.9.19 (main, Mar 19 2024, 16:08:27) 
[Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from virtualizarr import open_virtual_dataset

Traceback (most recent call last):
...
  File "/github/developmentseed/VirtualiZarr/virtualizarr/manifests/manifest.py", line 36, in ChunkEntry
    def from_kerchunk(cls, path_and_byte_range_info: list[str | int]) -> "ChunkEntry":
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```
as I believe the type union operator was only implemented in 3.10: https://docs.python.org/3/whatsnew/3.10.html#pep-604-new-type-union-operator

