### PR TITLE
Pass args and add test

### DIFF
--- a/virtualizarr/tests/test_xarray.py
+++ b/virtualizarr/tests/test_xarray.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -303,3 +304,16 @@ class TestLoadVirtualDataset:
         for name in full_ds.variables:
             if name in vars_to_load:
                 xrt.assert_identical(vds.variables[name], full_ds.variables[name])
+
+    @patch("virtualizarr.kerchunk.read_kerchunk_references_from_file")
+    def test_open_virtual_dataset_passes_expected_args(
+        self, mock_read_kerchunk, netcdf4_file
+    ):
+        reader_options = {"option1": "value1", "option2": "value2"}
+        open_virtual_dataset(netcdf4_file, indexes={}, reader_options=reader_options)
+        args = {
+            "filepath": netcdf4_file,
+            "filetype": None,
+            "reader_options": reader_options,
+        }
+        mock_read_kerchunk.assert_called_once_with(**args)

--- a/virtualizarr/xarray.py
+++ b/virtualizarr/xarray.py
@@ -108,6 +108,7 @@ def open_virtual_dataset(
         vds_refs = kerchunk.read_kerchunk_references_from_file(
             filepath=filepath,
             filetype=filetype,
+            reader_options=reader_options,
         )
         virtual_vars = virtual_vars_from_kerchunk_refs(
             vds_refs,


### PR DESCRIPTION
I noticed that reader_options were not being passed through to `read_kerchunk_references_from_file` in `open_virtual_dataset` when I was trying out the library with some files on S3 (e.g. `open_virtual_dataset(s3_link, reader_options={'storage_options': aws_creds})` would get a Forbidden error, see https://gist.github.com/abarciauskas-bgse/629702733946b1ec0b008f659dbc3406 for reproducible example).

This PR just adds one line so those args are passed through. I added a test but not sure if that is overkill for such a small change.