### PR TITLE
Fix upstream CI: install pyerfa in the upstream env for FITS tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,7 @@ test-py313 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "hdf4", "icechu
 test-py314 = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "hdf4", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr", "py314"] # test against python 3.14
 minio = ["dev", "remote", "hdf", "netcdf3", "fits", "hdf4", "icechunk", "kerchunk", "hdf5-lib", "py314", "zarr", "minio"]
 minimum-versions = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "hdf4", "tiff", "grib", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "zarr","minimum-versions", "py312"]
-upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "icechunk-dev", "upstream-overlay", "zarr", "py313"]
+upstream = ["dev", "test", "hdf", "hdf5-lib", "netcdf3", "fits", "icechunk-dev", "upstream-overlay", "zarr", "py313"]
 all = ["dev", "test", "remote", "hdf", "netcdf3", "fits", "hdf4", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "grib", "zarr", "all_parsers", "all_writers", "py313"]
 docs = ["docs", "dev", "remote", "hdf", "netcdf3", "fits", "hdf4", "icechunk", "kerchunk", "kerchunk_parquet", "hdf5-lib", "tiff", "grib","zarr", "py313"]
 


### PR DESCRIPTION
## What

The scheduled `Upstream` CI job is failing on `test_open_hubble_data`:

```
ModuleNotFoundError: No module named 'erfa'
...
ImportError: astropy is required for kerchunking FITS files.
```

(e.g. [this run](https://github.com/TomNicholas/VirtualiZarr/actions/runs/29626649204/job/88032301535))

## Root cause

Since #997 decoupled upstream dev-version testing from the pixi workspace, `astropy` is installed via `pip install --upgrade --no-deps -r ci/upstream-overrides.txt`. But the `upstream` pixi environment never included the `fits` feature, so the conda solve never provided astropy's `pyerfa` dependency (which supplies the `erfa` module) either.

The result was a half-installed astropy: `pytest.importorskip("astropy")` passed (top-level import works), but `kerchunk.fits`'s use of `astropy.coordinates` triggered `import erfa` and crashed. So the test **failed** instead of being skipped.

## Fix

Add the `fits` feature to the `upstream` environment so pixi resolves `astropy` + `pyerfa`. The overlay's `--no-deps` upgrade of astropy from git `main` then leaves `pyerfa` intact.

This also means the upstream job now actually exercises the FITS parser against bleeding-edge astropy — matching the clear intent of already listing `astropy @ git+...` in `ci/upstream-overrides.txt`.

Verified locally with `pixi lock` that `pyerfa` now appears in the `upstream` environment.